### PR TITLE
when serving a particular game, the order of the teams that was given…

### DIFF
--- a/app/Http/Controllers/GameController.php
+++ b/app/Http/Controllers/GameController.php
@@ -76,7 +76,9 @@ class GameController extends Controller {
         ]);
     }
     public function getOne(Request $request, $game_id) {
-        $game = Game::with(['sets', 'sets.points', 'teams', 'teams.members'])->find($game_id);
+        $game = Game::with(['sets', 'sets.points', 'teams' => function ($q) {
+            $q->withPivot('team_number')->orderBy('team_number');
+        }, 'teams.members'])->find($game_id);
         return self::successfulResponse([
             'game' => $game
         ]);


### PR DESCRIPTION
… was based on team id rather than their relative team number for that game. They are now properly ordered and the team_number column is available.