### PR TITLE
added totalPages property to returned info on pagination routes. This…

### DIFF
--- a/app/Http/Controllers/LeaderboardController.php
+++ b/app/Http/Controllers/LeaderboardController.php
@@ -63,14 +63,16 @@ class LeaderboardController extends Controller {
         if ($page < 0) $page = 1;
         $page--; // page 1 starts at offset 0, so page X is actually offset $size * (x - 1)
         if ($size <= 0) $size = 15;
+        $baseQuery = self::getLeaderboardTeams($playerCount, $season);
         $teams = self::getPaginated(
             $page,
             $size,
-            self::getLeaderboardTeams($playerCount, $season)
+            $baseQuery->clone()
         )->get();
         return self::successfulResponse([
             'teams' => self::mapResults($teams, $season),
-            'season_number' => $season->id
+            'season_number' => $season->id,
+            'totalPages' => ceil($baseQuery->count() / $size)
         ]);
     }
     public function singles(Request $request, Season $season) {

--- a/app/Http/Controllers/PlayerController.php
+++ b/app/Http/Controllers/PlayerController.php
@@ -27,13 +27,15 @@ class PlayerController extends Controller {
         if ($page < 0) $page = 1;
         $page--; // page 1 starts at offset 0, so page X is actually offset $size * (x - 1)
         if ($size <= 0) $size = 15;
+        $baseQuery = User::orderBy('created_at');
         $users = self::getPaginated(
             $page,
             $size,
-            User::orderBy('created_at')
+            $baseQuery->clone()
         )->get();
         return self::successfulResponse([
-            'players' => $users
+            'players' => $users,
+            'totalPages' => ceil($baseQuery->count() / $size)
         ]);
     }
     public function getOne(Request $request, $user_id) {


### PR DESCRIPTION
… property will tell the last page that can be requested by the server and still return at least 1 relavent item via the pagination routes. I imagine there is a more optimal method of computing this rather than performing 2 queries, but since it's just a count and a paginated value, i imagine it isn't too terrible